### PR TITLE
async_run

### DIFF
--- a/include/rpc.hpp
+++ b/include/rpc.hpp
@@ -1338,6 +1338,13 @@ std::string run(std::string_view obj_str) RPC_HPP_EXCEPT
     }
 }
 
+///@brief Entry point for running a function with rpc.hpp (asynchronous version)
+///
+/// Processes the serialization object and calls the function contained in the data.
+/// The call to this function is blocking, but non-blocking call(s) are made from here, returning quickly.
+///@tparam Serial The serialization object to utilize
+///@param obj The serialization object containing an object "function" with the function name,
+///@return std::future<std::string> Future containing the string representation of the result of the function call
 template<typename Serial>
 std::future<std::string> async_run(const Serial& obj) RPC_HPP_EXCEPT
 {
@@ -1358,6 +1365,13 @@ std::future<std::string> async_run(const Serial& obj) RPC_HPP_EXCEPT
     }
 }
 
+///@brief Entry point for running a function with rpc.hpp (asynchronous version)
+///
+/// Converts the string to a serialization object then processes it to call the function contained in the data.
+/// The call to this function is blocking, but non-blocking call(s) are made from here, returning quickly.
+///@tparam Serial The serialization object to utilize
+///@param obj_str A string representing the serialization object
+///@return std::future<std::string> Future containing the string representation of the result of the function call
 template<typename Serial>
 std::future<std::string> async_run(std::string_view obj_str) RPC_HPP_EXCEPT
 {

--- a/include/rpc.hpp
+++ b/include/rpc.hpp
@@ -41,6 +41,7 @@
 #include <array>
 #include <cstdint>
 #include <functional>
+#include <future>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -1292,7 +1293,7 @@ std::string run_callback(const Serial& obj, R (*func)(Args...)) RPC_HPP_EXCEPT
 /// and "args" with the functions arguments
 /// @return std::string The string representation of the result of the function call
 template<typename Serial>
-std::string run(const Serial& obj) RPC_HPP_EXCEPT
+std::future<std::string> run(const Serial& obj) RPC_HPP_EXCEPT
 {
     const auto adapter = serial_adapter<Serial>(obj);
     const auto func_name = adapter.template get_value<std::string>("function");
@@ -1300,7 +1301,7 @@ std::string run(const Serial& obj) RPC_HPP_EXCEPT
 
     try
     {
-        return dispatch<Serial>(func_name, argList);
+        return std::async(dispatch<Serial>, func_name, argList);
     }
     catch (std::exception& ex)
     {
@@ -1318,7 +1319,7 @@ std::string run(const Serial& obj) RPC_HPP_EXCEPT
 /// @param obj_str A string representing the serialization object
 /// @return std::string The string representation of the result of the function call
 template<typename Serial>
-std::string run(std::string_view obj_str) RPC_HPP_EXCEPT
+std::future<std::string> run(std::string_view obj_str) RPC_HPP_EXCEPT
 {
     const auto adapter = serial_adapter<Serial>(obj_str);
     const auto func_name = adapter.template get_value<std::string>("function");
@@ -1326,7 +1327,7 @@ std::string run(std::string_view obj_str) RPC_HPP_EXCEPT
 
     try
     {
-        return dispatch<Serial>(func_name, argList);
+        return std::async(dispatch<Serial>, func_name, argList);
     }
     catch (std::exception& ex)
     {


### PR DESCRIPTION
This merge adds `rpc::async_run` as an asynchronous version of the `rpc::run` function. It returns a `std::future<std::string>` instead of the normal `std::string`