### PR TITLE
Feature/magic enum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,18 @@ find_package(Threads)
 add_library(rpc_hpp INTERFACE)
 target_include_directories(rpc_hpp INTERFACE "${PROJECT_SOURCE_DIR}/include")
 target_link_libraries(rpc_hpp INTERFACE ${CMAKE_THREAD_LIBS_INIT})
+
+if(${USE_CONAN})
+  set(CONAN_EXTRA_REQUIRES magic_enum/[>=0.7.0])
+  run_conan()
+elseif(${USE_VCPKG})
+  find_package(magic_enum CONFIG REQUIRED)
+  target_link_libraries(rpc_hpp INTERFACE magic_enum::magic_enum)
+else()
+  find_path(magic_enum_path magic_enum.hpp)
+  target_include_directories(rpc_hpp SYSTEM INTERFACE magic_enum_path)
+endif()
+
 install(FILES "${PROJECT_SOURCE_DIR}/include/rpc.hpp"
         DESTINATION "${CMAKE_INSTALL_PREFIX}/include")
 

--- a/dispatch_gen.py
+++ b/dispatch_gen.py
@@ -55,29 +55,29 @@ with open(fname, "w") as f:
     f.write("RPC_FE2_0)(ACTION, __VA_ARGS__))\n\n")
 
     f.write(
-        "#define RPC_ATTACH_FUNC(FUNCNAME) if (func_name == #FUNCNAME) { return dispatch_func<Serial>(FUNCNAME, serial_obj); }\n"
+        "#define RPC_ATTACH_FUNC(FUNCNAME) case::FuncName::FUNCNAME: return dispatch_func<Serial>(FUNCNAME, serial_obj);\n"
     )
     f.write(
         "#define RPC_ATTACH_FUNCS(FUNCNAME, ...) EXPAND(RPC_FOR_EACH(RPC_ATTACH_FUNC, FUNCNAME, __VA_ARGS__))\n\n"
     )
     f.write(
-        "#define RPC_ATTACH_CACHED_FUNC(FUNCNAME) if (func_name == #FUNCNAME) { return dispatch_func<Serial>(FUNCNAME, serial_obj, true); }\n"
+        "#define RPC_ATTACH_CACHED_FUNC(FUNCNAME) case FuncName::FUNCNAME: return dispatch_func<Serial>(FUNCNAME, serial_obj, true);\n"
     )
     f.write(
         "#define RPC_ATTACH_CACHED_FUNCS(FUNCNAME, ...) EXPAND(RPC_FOR_EACH(RPC_ATTACH_CACHED_FUNC, FUNCNAME, __VA_ARGS__))\n\n"
     )
     f.write(
-        "#define RPC_ALIAS_FUNC(FUNCNAME, FUNC_ALIAS) if (func_name == #FUNC_ALIAS) { return dispatch_func<Serial>(FUNCNAME, serial_obj); }\n"
+        "#define RPC_ALIAS_FUNC(FUNCNAME, FUNC_ALIAS) case FuncName::FUNC_ALIAS: return dispatch_func<Serial>(FUNCNAME, serial_obj);\n"
     )
     f.write(
         "#define RPC_MULTI_ALIAS_FUNC(FUNCNAME, FUNC_ALIAS,...) EXPAND(RPC_FOR_EACH2(RPC_ALIAS_FUNC, FUNCNAME, FUNC_ALIAS, __VA_ARGS__))\n\n"
     )
     f.write(
-        "#define RPC_ALIAS_CACHED_FUNC(FUNCNAME, FUNC_ALIAS) if (func_name == #FUNC_ALIAS) { return dispatch_func<Serial>(FUNCNAME, serial_obj, true); }\n"
+        "#define RPC_ALIAS_CACHED_FUNC(FUNCNAME, FUNC_ALIAS) case FuncName::FUNC_ALIAS: return dispatch_func<Serial>(FUNCNAME, serial_obj, true);\n"
     )
     f.write(
         "#define RPC_MULTI_ALIAS_CACHED_FUNC(FUNCNAME, FUNC_ALIAS,...) EXPAND(RPC_FOR_EACH2(RPC_ALIAS_CACHED_FUNC, FUNCNAME, FUNC_ALIAS, __VA_ARGS__))\n\n"
     )
     f.write(
-        '#define RPC_DEFAULT_DISPATCH(FUNCNAME, ...) EXPAND(template<typename Serial> void rpc::server::dispatch(typename Serial::doc_type& serial_obj) { const auto func_name = serial_adapter<Serial>::extract_func_name(serial_obj); RPC_ATTACH_FUNCS(FUNCNAME, __VA_ARGS__) throw std::runtime_error("RPC error: Called function: \"" + func_name + "\" not found!");})\n'
+        '#define RPC_DEFAULT_DISPATCH(FUNCNAME, ...) EXPAND(template<typename Serial> void rpc::server::dispatch(typename Serial::doc_type& serial_obj) { const auto func_name = serial_adapter<Serial>::extract_func_name(serial_obj); const auto func_enum = magic_enum::enum_cast<FuncName>(func_name); if (!func_enum.has_value()) { throw std::runtime_error("RPC error: Called function: \"" + func_name + "\" not found!"); }  switch(*func_enum) { RPC_ATTACH_FUNCS(FUNCNAME, __VA_ARGS__) }})\n'
     )

--- a/include/rpc_dispatch_helper.hpp
+++ b/include/rpc_dispatch_helper.hpp
@@ -70,16 +70,10 @@
 #define RPC_FOR_EACH(ACTION, ...) EXPAND(RPC_GET_MACRO(_0, __VA_ARGS__, RPC_FE_30, RPC_FE_29, RPC_FE_28, RPC_FE_27, RPC_FE_26, RPC_FE_25, RPC_FE_24, RPC_FE_23, RPC_FE_22, RPC_FE_21, RPC_FE_20, RPC_FE_19, RPC_FE_18, RPC_FE_17, RPC_FE_16, RPC_FE_15, RPC_FE_14, RPC_FE_13, RPC_FE_12, RPC_FE_11, RPC_FE_10, RPC_FE_9, RPC_FE_8, RPC_FE_7, RPC_FE_6, RPC_FE_5, RPC_FE_4, RPC_FE_3, RPC_FE_2, RPC_FE_1, RPC_FE_0)(ACTION, __VA_ARGS__))
 #define RPC_FOR_EACH2(ACTION, ...) EXPAND(RPC_GET_MACRO(_0, __VA_ARGS__, RPC_FE2_30, RPC_FE2_29, RPC_FE2_28, RPC_FE2_27, RPC_FE2_26, RPC_FE2_25, RPC_FE2_24, RPC_FE2_23, RPC_FE2_22, RPC_FE2_21, RPC_FE2_20, RPC_FE2_19, RPC_FE2_18, RPC_FE2_17, RPC_FE2_16, RPC_FE2_15, RPC_FE2_14, RPC_FE2_13, RPC_FE2_12, RPC_FE2_11, RPC_FE2_10, RPC_FE2_9, RPC_FE2_8, RPC_FE2_7, RPC_FE2_6, RPC_FE2_5, RPC_FE2_4, RPC_FE2_3, RPC_FE2_2, RPC_FE2_1, RPC_FE2_0)(ACTION, __VA_ARGS__))
 
-#define RPC_ATTACH_FUNC(FUNCNAME) if (func_name == #FUNCNAME) { return dispatch_func<Serial>(FUNCNAME, serial_obj); }
+#define RPC_ATTACH_FUNC(FUNCNAME) case FuncName::FUNCNAME: return dispatch_func<Serial>(FUNCNAME, serial_obj);
 #define RPC_ATTACH_FUNCS(FUNCNAME, ...) EXPAND(RPC_FOR_EACH(RPC_ATTACH_FUNC, FUNCNAME, __VA_ARGS__))
 
-#define RPC_ATTACH_CACHED_FUNC(FUNCNAME) if (func_name == #FUNCNAME) { return dispatch_func<Serial>(FUNCNAME, serial_obj, true); }
+#define RPC_ATTACH_CACHED_FUNC(FUNCNAME) case FuncName::FUNCNAME: return dispatch_func<Serial>(FUNCNAME, serial_obj, true);
 #define RPC_ATTACH_CACHED_FUNCS(FUNCNAME, ...) EXPAND(RPC_FOR_EACH(RPC_ATTACH_CACHED_FUNC, FUNCNAME, __VA_ARGS__))
 
-#define RPC_ALIAS_FUNC(FUNCNAME, FUNC_ALIAS) if (func_name == #FUNC_ALIAS) { return dispatch_func<Serial>(FUNCNAME, serial_obj); }
-#define RPC_MULTI_ALIAS_FUNC(FUNCNAME, FUNC_ALIAS,...) EXPAND(RPC_FOR_EACH2(RPC_ALIAS_FUNC, FUNCNAME, FUNC_ALIAS, __VA_ARGS__))
-
-#define RPC_ALIAS_CACHED_FUNC(FUNCNAME, FUNC_ALIAS) if (func_name == #FUNC_ALIAS) { return dispatch_func<Serial>(FUNCNAME, serial_obj, true); }
-#define RPC_MULTI_ALIAS_CACHED_FUNC(FUNCNAME, FUNC_ALIAS,...) EXPAND(RPC_FOR_EACH2(RPC_ALIAS_CACHED_FUNC, FUNCNAME, FUNC_ALIAS, __VA_ARGS__))
-
-#define RPC_DEFAULT_DISPATCH(FUNCNAME, ...) EXPAND(template<typename Serial> void rpc::server::dispatch(typename Serial::doc_type& serial_obj) { const auto func_name = serial_adapter<Serial>::extract_func_name(serial_obj); RPC_ATTACH_FUNCS(FUNCNAME, __VA_ARGS__) throw std::runtime_error("RPC error: Called function: \"" + func_name + "\" not found!");})
+#define RPC_DEFAULT_DISPATCH(FUNCNAME, ...) EXPAND(template<typename Serial> void rpc::server::dispatch(typename Serial::doc_type& serial_obj) { const auto func_name = serial_adapter<Serial>::extract_func_name(serial_obj); switch(magic_enum::enum_cast<FuncName>(func_name)) { RPC_ATTACH_FUNCS(FUNCNAME, __VA_ARGS__) default: throw std::runtime_error("RPC error: Called function: \"" + func_name + "\" not found!"); }})

--- a/include/rpc_dispatch_helper.hpp
+++ b/include/rpc_dispatch_helper.hpp
@@ -76,4 +76,10 @@
 #define RPC_ATTACH_CACHED_FUNC(FUNCNAME) case FuncName::FUNCNAME: return dispatch_func<Serial>(FUNCNAME, serial_obj, true);
 #define RPC_ATTACH_CACHED_FUNCS(FUNCNAME, ...) EXPAND(RPC_FOR_EACH(RPC_ATTACH_CACHED_FUNC, FUNCNAME, __VA_ARGS__))
 
-#define RPC_DEFAULT_DISPATCH(FUNCNAME, ...) EXPAND(template<typename Serial> void rpc::server::dispatch(typename Serial::doc_type& serial_obj) { const auto func_name = serial_adapter<Serial>::extract_func_name(serial_obj); switch(magic_enum::enum_cast<FuncName>(func_name)) { RPC_ATTACH_FUNCS(FUNCNAME, __VA_ARGS__) default: throw std::runtime_error("RPC error: Called function: \"" + func_name + "\" not found!"); }})
+#define RPC_ALIAS_FUNC(FUNCNAME, FUNC_ALIAS) case FuncName::FUNC_ALIAS: return dispatch_func<Serial>(FUNCNAME, serial_obj);
+#define RPC_MULTI_ALIAS_FUNC(FUNCNAME, FUNC_ALIAS,...) EXPAND(RPC_FOR_EACH2(RPC_ALIAS_FUNC, FUNCNAME, FUNC_ALIAS, __VA_ARGS__))
+
+#define RPC_ALIAS_CACHED_FUNC(FUNCNAME, FUNC_ALIAS) case FuncName::FUNC_ALIAS: return dispatch_func<Serial>(FUNCNAME, serial_obj, true);
+#define RPC_MULTI_ALIAS_CACHED_FUNC(FUNCNAME, FUNC_ALIAS,...) EXPAND(RPC_FOR_EACH2(RPC_ALIAS_CACHED_FUNC, FUNCNAME, FUNC_ALIAS, __VA_ARGS__))
+
+#define RPC_DEFAULT_DISPATCH(FUNCNAME, ...) EXPAND(template<typename Serial> void rpc::server::dispatch(typename Serial::doc_type& serial_obj) { const auto func_name = serial_adapter<Serial>::extract_func_name(serial_obj); const auto func_enum = magic_enum::enum_cast<FuncName>(func_name); if (!func_enum.has_value()) { throw std::runtime_error("RPC error: Called function: \"" + func_name + "\" not found!"); }  switch(*func_enum) { RPC_ATTACH_FUNCS(FUNCNAME, __VA_ARGS__) }})

--- a/meson.build
+++ b/meson.build
@@ -82,6 +82,7 @@ elif cpp_compiler == 'msvc'
 endif
 
 thread_dep = dependency('threads')
+magic_enum_dep = dependency('magic_enum', version : ['>=0.7.0'])
 
 include_dirs = include_directories('./include')
 rpc_hpp_dep = declare_dependency(include_directories : include_dirs, dependencies : thread_dep)

--- a/tests/rpc.benchmark.cpp
+++ b/tests/rpc.benchmark.cpp
@@ -454,7 +454,7 @@ TEST_CASE("With Container", "[container][cached]")
             9783.49, 125.12, 553.3333333333, 2266.1 };
 
         test = *rpc::call<njson_serial_t, double>(
-            GetClient<njson_serial_t>(), "AverageContainer<double>", vec)
+            GetClient<njson_serial_t>(), "AverageContainer_double", vec)
                     .get_result();
     };
 
@@ -469,7 +469,7 @@ TEST_CASE("With Container", "[container][cached]")
             9783.49, 125.12, 553.3333333333, 2266.1 };
 
         test = *rpc::call<rpdjson_serial_t, double>(
-            GetClient<rpdjson_serial_t>(), "AverageContainer<double>", vec)
+            GetClient<rpdjson_serial_t>(), "AverageContainer_double", vec)
                     .get_result();
     };
 #endif
@@ -483,7 +483,7 @@ TEST_CASE("With Container", "[container][cached]")
             9783.49, 125.12, 553.3333333333, 2266.1 };
 
         test = *rpc::call<bjson_serial_t, double>(
-            GetClient<bjson_serial_t>(), "AverageContainer<double>", vec)
+            GetClient<bjson_serial_t>(), "AverageContainer_double", vec)
                     .get_result();
     };
 #endif
@@ -505,7 +505,7 @@ TEST_CASE("Sequential", "[sequential][cached]")
         }
 
         return *rpc::call<njson_serial_t, double>(
-            GetClient<njson_serial_t>(), "AverageContainer<uint64_t>", vec)
+            GetClient<njson_serial_t>(), "AverageContainer_uint64_t", vec)
                     .get_result();
     };
 
@@ -524,7 +524,7 @@ TEST_CASE("Sequential", "[sequential][cached]")
         }
 
         return *rpc::call<rpdjson_serial_t, double>(
-            GetClient<rpdjson_serial_t>(), "AverageContainer<uint64_t>", vec)
+            GetClient<rpdjson_serial_t>(), "AverageContainer_uint64_t", vec)
                     .get_result();
     };
 #endif
@@ -544,7 +544,7 @@ TEST_CASE("Sequential", "[sequential][cached]")
         }
 
         return *rpc::call<bjson_serial_t, double>(
-            GetClient<bjson_serial_t>(), "AverageContainer<uint64_t>", vec)
+            GetClient<bjson_serial_t>(), "AverageContainer_uint64_t", vec)
                     .get_result();
     };
 #endif
@@ -768,7 +768,8 @@ TEST_CASE("By Pointer (many)", "[pointer][many]")
 }
 #endif
 
-TEST_CASE("KillServer", "[!mayfail][value][simple][cached][ref][complex][sequential][pointer][many][container]")
+TEST_CASE("KillServer",
+    "[!mayfail][value][simple][cached][ref][complex][sequential][pointer][many][container]")
 {
     auto& client = GetClient<njson_serial_t>();
 

--- a/tests/rpc.server.cpp
+++ b/tests/rpc.server.cpp
@@ -437,16 +437,6 @@ double AverageContainer(const std::vector<T>& vec)
     return sum / static_cast<double>(vec.size());
 }
 
-inline double AverageContainer_double(const std::vector<double>& vec)
-{
-    return AverageContainer<double>(vec);
-}
-
-inline double AverageContainer_uint64_t(const std::vector<uint64_t>& vec)
-{
-    return AverageContainer<uint64_t>(vec);
-}
-
 std::vector<uint64_t> RandInt(const uint64_t min, const uint64_t max, const size_t sz = 1000)
 {
     std::vector<uint64_t> vec;
@@ -547,12 +537,11 @@ void rpc::server::dispatch(typename Serial::doc_type& serial_obj)
             ReadMessageVec, WriteMessageVec, ClearBus, FibonacciRef, SquareRootRef, RandInt,
             HashComplexRef)
 
-        RPC_ATTACH_CACHED_FUNCS(AddAllPtr, SimpleSum, StrLen, AddOneToEach, Fibonacci, Average,
-            StdDev, AverageContainer_double, AverageContainer_uint64_t, HashComplex)
+        RPC_ATTACH_CACHED_FUNCS(
+            AddAllPtr, SimpleSum, StrLen, AddOneToEach, Fibonacci, Average, StdDev, HashComplex)
 
-        default:
-            throw std::runtime_error(
-                "RPC error: Called function: \"" + func_name + "\" not found!");
+        RPC_ALIAS_CACHED_FUNC(AverageContainer<double>, AverageContainer_double)
+        RPC_ALIAS_CACHED_FUNC(AverageContainer<uint64_t>, AverageContainer_uint64_t)
     }
 }
 
@@ -574,12 +563,11 @@ void rpc::server::dispatch(typename Serial::doc_type& serial_obj)
             ReadMessageVec, WriteMessageVec, ClearBus, FibonacciRef, SquareRootRef, RandInt,
             HashComplexRef)
 
-        RPC_ATTACH_CACHED_FUNCS(SimpleSum, StrLen, AddOneToEach, Fibonacci, Average, StdDev,
-            AverageContainer_double, AverageContainer_uint64_t, HashComplex)
+        RPC_ATTACH_CACHED_FUNCS(
+            SimpleSum, StrLen, AddOneToEach, Fibonacci, Average, StdDev, HashComplex)
 
-        default:
-            throw std::runtime_error(
-                "RPC error: Called function: \"" + func_name + "\" not found!");
+        RPC_ALIAS_CACHED_FUNC(AverageContainer<double>, AverageContainer_double)
+        RPC_ALIAS_CACHED_FUNC(AverageContainer<uint64_t>, AverageContainer_uint64_t)
     }
 }
 #endif

--- a/tests/rpc.test.cpp
+++ b/tests/rpc.test.cpp
@@ -378,7 +378,7 @@ TEST_CASE("AverageContainer<double>")
         125.12, 553.3333333333, 2266.1 };
 
     const auto test =
-        *rpc::call<test_serial_t, double>(client, "AverageContainer<double>", vec).get_result();
+        *rpc::call<test_serial_t, double>(client, "AverageContainer_double", vec).get_result();
 
     REQUIRE_THAT(test, Catch::Matchers::WithinAbs(expected, 0.001));
 }
@@ -433,5 +433,5 @@ TEST_CASE("KillServer", "[!mayfail]")
     {
     }
 
-    REQUIRE_THROWS(TestType<njson_serial_t>());
+    REQUIRE_THROWS(TestType<test_serial_t>());
 }


### PR DESCRIPTION
Use magic_enum instead of string compare for function dispatch

Pros:

- Can use a `switch` statement instead of multiple `if`s
  - _Potential_ performance improvement
- Can potentially provide support for more strict typing in the future
  - Could store return and/or arg types in a `tuple` bounded to the `enum` value
- Could allow for stricter contract between client and server
  - Both share a header with the `enum` in it, restricting the client to only valid functions
  - Could allow for more static serialization methods like protobuf, etc. where types must be known

Cons:

- Introduces a dependency at the top level (though it is header-only)
- Less flexible aliasing
  - Requires at least the server to add a new `enum` value for aliases
- _Potential_ performance loss (though unlikely)
  - Some compilers might be able to optimize the string compare better
- **Requires newer compilers**:
  - clang >= 5
  - gcc >= 9 _(probably the biggest issue)_
  - MSVC >= 15.3
- Potentially longer compile times

Possible solutions:

- Make magic_enum an option (a la `#define RPC_HPP_USE_MAGIC_ENUM` or similar)
  - Could also provide an option for strict 1:1 (JSON contains integer representation of enum, not string. `#define RPC_HPP_STRICT_CALL` or similar)

