### PR TITLE
Experimental/variants

### DIFF
--- a/include/rpc.hpp
+++ b/include/rpc.hpp
@@ -837,7 +837,7 @@ public:
     {
         RPC_HPP_PRECONDITION(!is_empty());
 
-        auto type = Serial::get_type(m_obj);
+        const auto type = Serial::get_type(m_obj);
 
         RPC_HPP_POSTCONDITION(validate_rpc_type(type));
         return type;
@@ -1202,19 +1202,19 @@ namespace adapters
     }
 
     template<typename Adapter, bool Deserialize>
-    void serialize(serializer_base<Adapter, Deserialize>& ser, std::nullptr_t& val)
+    void serialize(serializer_base<Adapter, Deserialize>& ser, RPC_HPP_UNUSED std::nullptr_t& val)
     {
         ser.as_null("");
     }
 
     template<typename Adapter, bool Deserialize>
-    void serialize(serializer_base<Adapter, Deserialize>& ser, std::nullopt_t& val)
+    void serialize(serializer_base<Adapter, Deserialize>& ser, RPC_HPP_UNUSED std::nullopt_t& val)
     {
         ser.as_null("");
     }
 
     template<typename Adapter, bool Deserialize>
-    void serialize(serializer_base<Adapter, Deserialize>& ser, std::monostate& val)
+    void serialize(serializer_base<Adapter, Deserialize>& ser, RPC_HPP_UNUSED std::monostate& val)
     {
         ser.as_null("");
     }

--- a/include/rpc_adapters/rpc_bitsery.hpp
+++ b/include/rpc_adapters/rpc_bitsery.hpp
@@ -183,7 +183,7 @@ namespace detail_bitsery
     class serializer : public serializer_base<serial_adapter, false>
     {
     public:
-        serializer() : m_ser(m_bytes) { m_bytes.reserve(64UL); }
+        serializer() noexcept : m_ser(m_bytes) { m_bytes.reserve(64UL); }
 
         [[nodiscard]] auto object() & -> const std::vector<uint8_t>&
         {
@@ -469,7 +469,7 @@ namespace detail_bitsery
             serial_adapter::parse_obj(m_ser, *this, val);
         }
 
-        void as_object(RPC_HPP_UNUSED const std::string_view key)
+        void as_null(RPC_HPP_UNUSED const std::string_view key)
         {
             // nop
         }

--- a/include/rpc_adapters/rpc_boost_json.hpp
+++ b/include/rpc_adapters/rpc_boost_json.hpp
@@ -146,7 +146,7 @@ namespace detail_boost_json
         template<typename T>
         void as_float(const std::string_view key, const T& val)
         {
-            subobject(key) = val;
+            subobject(key) = static_cast<double>(val);
         }
 
         template<typename T>
@@ -271,11 +271,27 @@ namespace detail_boost_json
             }
         }
 
+        template<typename... Args>
+        void as_variant(const std::string_view key, const std::variant<Args...>& val)
+        {
+            auto obj = boost::json::object{};
+            obj["v_idx"] = val.index();
+            auto var_val = boost::json::value{};
+            std::visit([&var_val](auto&& l_val)
+                { push_arg(std::forward<decltype(l_val)>(l_val), var_val); },
+                val);
+
+            obj["v_val"] = std::move(var_val);
+            subobject(key) = std::move(obj);
+        }
+
         template<typename T>
         void as_object(const std::string_view key, const T& val)
         {
             push_arg(val, subobject(key));
         }
+
+        void as_null(const std::string_view key) { subobject(key).emplace_null(); }
 
     private:
         [[nodiscard]] auto subobject(const std::string_view key) -> boost::json::value&
@@ -297,7 +313,7 @@ namespace detail_boost_json
         {
             boost::json::value tmp{};
             push_arg(std::forward<T>(arg), tmp);
-            obj_arr.push_back(tmp);
+            obj_arr.push_back(std::move(tmp));
         }
 
         boost::json::value m_json{};
@@ -443,10 +459,115 @@ namespace detail_boost_json
                                 : std::optional<T>{ std::in_place, boost::json::value_to<T>(obj) };
         }
 
+        template<typename... Args>
+        void as_variant(const std::string_view key, std::variant<Args...>& val) const
+        {
+            static constexpr size_t arg_sz = sizeof...(Args);
+
+            const auto& obj = subobject(key);
+            const auto v_idx = boost::json::value_to<size_t>(obj.at("v_idx"));
+
+            if (v_idx >= arg_sz)
+            {
+                throw deserialization_error{
+                    std::string{ "Boost.JSON error: variant index exceeded variant size: " }.append(
+                        std::to_string(arg_sz))
+                };
+            }
+
+            // TODO: Cleanup and move to serial-agnostic code
+            switch (v_idx)
+            {
+                case 0:
+                    val = parse_arg<decltype(std::get<0>(val))>(obj.at("v_val"));
+                    return;
+
+                case 1:
+                    if constexpr (arg_sz > 1)
+                    {
+                        val = parse_arg<decltype(std::get<1>(val))>(obj.at("v_val"));
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 2:
+                    if constexpr (arg_sz > 2)
+                    {
+                        val = parse_arg<decltype(std::get<2>(val))>(obj.at("v_val"));
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 3:
+                    if constexpr (arg_sz > 3)
+                    {
+                        val = parse_arg<decltype(std::get<3>(val))>(obj.at("v_val"));
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 4:
+                    if constexpr (arg_sz > 4)
+                    {
+                        val = parse_arg<decltype(std::get<4>(val))>(obj.at("v_val"));
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 5:
+                    if constexpr (arg_sz > 5)
+                    {
+                        val = parse_arg<decltype(std::get<5>(val))>(obj.at("v_val"));
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 6:
+                    if constexpr (arg_sz > 6)
+                    {
+                        val = parse_arg<decltype(std::get<6>(val))>(obj.at("v_val"));
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 7:
+                    if constexpr (arg_sz > 7)
+                    {
+                        val = parse_arg<decltype(std::get<7>(val))>(obj.at("v_val"));
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 8:
+                    if constexpr (arg_sz > 8)
+                    {
+                        val = parse_arg<decltype(std::get<8>(val))>(obj.at("v_val"));
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 9:
+                    if constexpr (arg_sz > 9)
+                    {
+                        val = parse_arg<decltype(std::get<9>(val))>(obj.at("v_val"));
+                        return;
+                    }
+                    [[fallthrough]];
+
+                default:
+                    RPC_HPP_ASSUME(0);
+            }
+        }
+
         template<typename T>
         void as_object(const std::string_view key, T& val) const
         {
             val = parse_arg<T>(subobject(key));
+        }
+
+        void as_null(RPC_HPP_UNUSED const std::string_view key) const
+        {
+            RPC_HPP_PRECONDITION(subobject(key).is_null());
         }
 
     private:
@@ -487,6 +608,11 @@ namespace detail_boost_json
             else if constexpr (detail::is_container_v<T>)
             {
                 return arg.is_array();
+            }
+            else if constexpr (std::is_same_v<T, std::nullptr_t>
+                || std::is_same_v<T, std::monostate> || std::is_same_v<T, std::nullopt_t>)
+            {
+                return arg.is_null();
             }
             else
             {

--- a/include/rpc_adapters/rpc_rapidjson.hpp
+++ b/include/rpc_adapters/rpc_rapidjson.hpp
@@ -912,7 +912,7 @@ namespace detail_rapidjson
             throw deserialization_error{ R"(rapidjson error: field "func_name" not found)" };
         }
 
-        const rpc_type type = static_cast<rpc_type>(type_it->value.GetInt());
+        const auto type = static_cast<rpc_type>(type_it->value.GetInt());
 
         if (!validate_rpc_type(type))
         {

--- a/include/rpc_adapters/rpc_rapidjson.hpp
+++ b/include/rpc_adapters/rpc_rapidjson.hpp
@@ -137,22 +137,18 @@ namespace detail_rapidjson
 
         [[nodiscard]] auto object() const& -> const rapidjson::Document&
         {
-            RPC_HPP_PRECONDITION(m_json.IsObject()
-                    ? !m_json.ObjectEmpty()
-                    : (m_json.IsArray()
-                            ? !m_json.Empty()
-                            : (m_json.IsString() ? m_json.GetStringLength() != 0 : true)));
+            RPC_HPP_PRECONDITION(m_json.IsNull()
+                || (m_json.IsObject() ? !m_json.ObjectEmpty()
+                                      : (m_json.IsArray() ? !m_json.Empty() : true)));
 
             return m_json;
         }
 
         [[nodiscard]] auto object() && -> rapidjson::Document&&
         {
-            RPC_HPP_PRECONDITION(m_json.IsObject()
-                    ? !m_json.ObjectEmpty()
-                    : (m_json.IsArray()
-                            ? !m_json.Empty()
-                            : (m_json.IsString() ? m_json.GetStringLength() != 0 : true)));
+            RPC_HPP_PRECONDITION(m_json.IsNull()
+                || (m_json.IsObject() ? !m_json.ObjectEmpty()
+                                      : (m_json.IsArray() ? !m_json.Empty() : true)));
 
             return std::move(m_json);
         }
@@ -296,11 +292,28 @@ namespace detail_rapidjson
             }
         }
 
+        template<typename... Args>
+        void as_variant(const std::string_view key, const std::variant<Args...>& val)
+        {
+            auto& obj = subobject(key).SetObject();
+            obj.AddMember("v_idx", val.index(), allocator());
+            std::visit(
+                [this, &obj](const auto& l_val)
+                {
+                    serializer ser{};
+                    ser.serialize_object(l_val);
+                    obj.AddMember("v_val", std::move(ser).object(), allocator());
+                },
+                val);
+        }
+
         template<typename T>
         void as_object(const std::string_view key, const T& val)
         {
             push_arg(val, subobject(key), allocator());
         }
+
+        void as_null(const std::string_view key) { subobject(key).SetNull(); }
 
     private:
         [[nodiscard]] auto subobject(const std::string_view key) -> rapidjson::Value&
@@ -367,11 +380,9 @@ namespace detail_rapidjson
     public:
         explicit deserializer(const rapidjson::Value& obj) : m_json(obj)
         {
-            RPC_HPP_POSTCONDITION(m_json.IsObject()
-                    ? !m_json.ObjectEmpty()
-                    : (m_json.IsArray()
-                            ? !m_json.Empty()
-                            : (m_json.IsString() ? m_json.GetStringLength() != 0 : true)));
+            RPC_HPP_POSTCONDITION(m_json.IsNull()
+                || (m_json.IsObject() ? !m_json.ObjectEmpty()
+                                      : (m_json.IsArray() ? !m_json.Empty() : true)));
         }
 
         template<typename T>
@@ -527,10 +538,115 @@ namespace detail_rapidjson
                                : std::optional<T>{ std::in_place, parse_arg<T>(obj) };
         }
 
+        template<typename... Args>
+        void as_variant(const std::string_view key, std::variant<Args...>& val) const
+        {
+            static constexpr size_t arg_sz = sizeof...(Args);
+
+            const auto& obj = subobject(key);
+            const auto v_idx = obj["v_idx"].GetUint();
+
+            if (v_idx >= arg_sz)
+            {
+                throw deserialization_error{
+                    std::string{ "rapidjson error: variant index exceeded variant size: " }.append(
+                        std::to_string(arg_sz))
+                };
+            }
+
+            // TODO: Cleanup and move to serial-agnostic code
+            switch (v_idx)
+            {
+                case 0:
+                    val = parse_arg<decltype(std::get<0>(val))>(obj["v_val"]);
+                    return;
+
+                case 1:
+                    if constexpr (arg_sz > 1)
+                    {
+                        val = parse_arg<decltype(std::get<1>(val))>(obj["v_val"]);
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 2:
+                    if constexpr (arg_sz > 2)
+                    {
+                        val = parse_arg<decltype(std::get<2>(val))>(obj["v_val"]);
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 3:
+                    if constexpr (arg_sz > 3)
+                    {
+                        val = parse_arg<decltype(std::get<3>(val))>(obj["v_val"]);
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 4:
+                    if constexpr (arg_sz > 4)
+                    {
+                        val = parse_arg<decltype(std::get<4>(val))>(obj["v_val"]);
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 5:
+                    if constexpr (arg_sz > 5)
+                    {
+                        val = parse_arg<decltype(std::get<5>(val))>(obj["v_val"]);
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 6:
+                    if constexpr (arg_sz > 6)
+                    {
+                        val = parse_arg<decltype(std::get<6>(val))>(obj["v_val"]);
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 7:
+                    if constexpr (arg_sz > 7)
+                    {
+                        val = parse_arg<decltype(std::get<7>(val))>(obj["v_val"]);
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 8:
+                    if constexpr (arg_sz > 8)
+                    {
+                        val = parse_arg<decltype(std::get<8>(val))>(obj["v_val"]);
+                        return;
+                    }
+                    [[fallthrough]];
+
+                case 9:
+                    if constexpr (arg_sz > 9)
+                    {
+                        val = parse_arg<decltype(std::get<9>(val))>(obj["v_val"]);
+                        return;
+                    }
+                    [[fallthrough]];
+
+                default:
+                    RPC_HPP_ASSUME(0);
+            }
+        }
+
         template<typename T>
         void as_object(const std::string_view key, T& val) const
         {
             val = parse_arg<T>(subobject(key));
+        }
+
+        void as_null(RPC_HPP_UNUSED const std::string_view key) const
+        {
+            RPC_HPP_PRECONDITION(subobject(key).IsNull());
         }
 
     private:
@@ -602,6 +718,11 @@ namespace detail_rapidjson
             else if constexpr (rpc_hpp::detail::is_container_v<T>)
             {
                 return arg.IsArray();
+            }
+            else if constexpr (std::is_same_v<T, std::nullptr_t>
+                || std::is_same_v<T, std::monostate> || std::is_same_v<T, std::nullopt_t>)
+            {
+                return arg.IsNull();
             }
             else
             {

--- a/include/rpc_client.hpp
+++ b/include/rpc_client.hpp
@@ -300,7 +300,7 @@ private:
 
         RPC_HPP_PRECONDITION(!std::string_view{ func_name }.empty());
 
-        auto [iter, status] = m_callback_map.try_emplace(std::forward<S>(func_name),
+        const auto [iter, status] = m_callback_map.try_emplace(std::forward<S>(func_name),
             [func = std::forward<F>(func)](object_t& rpc_obj)
             {
                 try

--- a/include/rpc_server.hpp
+++ b/include/rpc_server.hpp
@@ -144,7 +144,7 @@ private:
 
         RPC_HPP_PRECONDITION(!std::string_view{ func_name }.empty());
 
-        auto [iter, status] = m_dispatch_table.try_emplace(std::forward<S>(func_name),
+        const auto [iter, status] = m_dispatch_table.try_emplace(std::forward<S>(func_name),
             [func = std::forward<F>(func)](object_t& rpc_obj)
             {
                 RPC_HPP_PRECONDITION(rpc_obj.get_type() == rpc_type::func_request);

--- a/tests/sync_queue.hpp
+++ b/tests/sync_queue.hpp
@@ -52,15 +52,15 @@ template<typename T>
 class SyncQueue
 {
 public:
-    void activate() { m_active.store(true); }
+    void activate() noexcept { m_active.store(true); }
 
-    void deactivate()
+    void deactivate() noexcept
     {
         m_active.store(false);
         m_cv.notify_all();
     }
 
-    [[nodiscard]] bool is_active() const { return m_active.load(); }
+    [[nodiscard]] bool is_active() const noexcept { return m_active.load(); }
 
     void push(const T& val)
     {

--- a/tests/test_client.cpp
+++ b/tests/test_client.cpp
@@ -413,6 +413,72 @@ TEST_CASE_TEMPLATE("SafeDivide", TestType, RPC_TEST_TYPES)
     REQUIRE(!result2.has_value());
 }
 
+TEST_CASE_TEMPLATE("TypeName", TestType, RPC_TEST_TYPES)
+{
+    auto p_client = GetClient<TestType>();
+
+    std::variant<bool, int, float, std::string> v = true;
+    const auto response_b = p_client->call_func("TypeName", v);
+
+    CHECK(response_b.get_type() == rpc_type::func_result);
+    REQUIRE(response_b.template get_result<std::string>() == "bool");
+
+    v = 22;
+    const auto response_n = p_client->call_func("TypeName", v);
+
+    CHECK(response_n.get_type() == rpc_type::func_result);
+    REQUIRE(response_n.template get_result<std::string>() == "int");
+
+    v = 6.35f;
+    const auto response_f = p_client->call_func("TypeName", v);
+
+    CHECK(response_f.get_type() == rpc_type::func_result);
+    REQUIRE(response_f.template get_result<std::string>() == "float");
+
+    v = std::string{ "TestString" };
+    const auto response_s = p_client->call_func("TypeName", v);
+
+    CHECK(response_s.get_type() == rpc_type::func_result);
+    REQUIRE(response_s.template get_result<std::string>() == "string");
+}
+
+TEST_CASE_TEMPLATE("VariantResult", TestType, RPC_TEST_TYPES)
+{
+    const auto p_client = GetClient<TestType>();
+
+    using result_t = std::variant<std::monostate, int, std::string>;
+
+    const auto response1 = p_client->call_func("VariantResult", "GetInt");
+
+    CHECK(response1.get_type() == rpc_type::func_result);
+
+    const auto result1 = response1.template get_result<result_t>();
+
+    REQUIRE(std::holds_alternative<int>(result1));
+    REQUIRE(std::get<int>(result1) == 42);
+
+    // TODO: Add functionality to get result from variant directly
+    //const auto test_n = response1.template get_result<int>();
+    //REQUIRE(test_n == 42);
+
+    const auto response2 = p_client->call_func("VariantResult", "GetName");
+
+    CHECK(response2.get_type() == rpc_type::func_result);
+
+    const auto result2 = response2.template get_result<result_t>();
+
+    REQUIRE(std::holds_alternative<std::string>(result2));
+    REQUIRE_FALSE(std::get<std::string>(result2).empty());
+
+    const auto response3 = p_client->call_func("VariantResult", "BadVar");
+
+    CHECK(response3.get_type() == rpc_type::func_result);
+
+    const auto result3 = response3.template get_result<result_t>();
+
+    REQUIRE(std::holds_alternative<std::monostate>(result3));
+}
+
 TEST_CASE_TEMPLATE("TopTwo", TestType, RPC_TEST_TYPES)
 {
     auto p_client = GetClient<TestType>();

--- a/tests/test_client.hpp
+++ b/tests/test_client.hpp
@@ -53,9 +53,9 @@ public:
     using typename callback_client_interface<Serial>::bytes_t;
     using typename callback_client_interface<Serial>::object_t;
 
-    explicit TestClient(std::shared_ptr<TestServer<Serial>> server)
+    explicit TestClient(TestServer<Serial>& server)
         : m_p_message_queue{ std::make_shared<SyncQueue<bytes_t>>() },
-          m_p_server_queue(server->attach_client(m_p_message_queue))
+          m_p_server_queue(server.attach_client(m_p_message_queue))
     {
         m_p_message_queue->activate();
     }
@@ -130,7 +130,7 @@ std::shared_ptr<TestClient<Serial>> GetClient()
 
     if (!p_client)
     {
-        p_client = std::make_shared<TestClient<Serial>>(GetServer<Serial>());
+        p_client = std::make_shared<TestClient<Serial>>(*GetServer<Serial>());
     }
 
     return p_client;

--- a/tests/test_server.cpp
+++ b/tests/test_server.cpp
@@ -277,6 +277,35 @@ std::optional<int> SafeDivide(int numerator, int denominator) noexcept
     return numerator / denominator;
 }
 
+std::string TypeName(const std::variant<bool, int, float, std::string>& var)
+{
+    struct Visitor
+    {
+        std::string operator()([[maybe_unused]] bool b) const { return "bool"; }
+        std::string operator()([[maybe_unused]] int n) const { return "int"; }
+        std::string operator()([[maybe_unused]] float f) const { return "float"; }
+        std::string operator()([[maybe_unused]] const std::string& s) const { return "string"; }
+    };
+
+    return std::visit(Visitor(), var);
+}
+
+std::variant<std::monostate, int, std::string> VariantResult(std::string_view input)
+{
+    if (input == "GetInt")
+    {
+        return 42;
+    }
+    else if (input == "GetName")
+    {
+        return std::string{ "Georgie Porgie" };
+    }
+    else
+    {
+        return {};
+    }
+}
+
 std::pair<int, int> TopTwo(const std::vector<int>& num_list) noexcept
 {
     // TODO: Replace this naive version with algorithm (transform/reduce?)
@@ -371,6 +400,8 @@ static void BindFuncs(TestServer<Serial>& server)
     server.bind("HashComplexRef", &HashComplexRef);
     server.bind("SquareArray", &SquareArray);
     server.bind("RemoveFromList", &RemoveFromList);
+    server.bind("TypeName", &TypeName);
+    server.bind("VariantResult", &VariantResult);
     server.template bind<void, size_t&>("AddOne", [](size_t& n) noexcept { ::AddOne(n); });
 
     // Cached

--- a/tests/test_server.cpp
+++ b/tests/test_server.cpp
@@ -86,13 +86,13 @@ namespace rpc_hpp::tests
 }
 
 // cached
-size_t StrLen(std::string_view str) noexcept
+constexpr size_t StrLen(std::string_view str) noexcept
 {
     return str.size();
 }
 
 // cached
-constexpr int SimpleSum(const int num1, const int num2)
+constexpr int SimpleSum(const int num1, const int num2) noexcept
 {
     return num1 + num2;
 }
@@ -100,7 +100,7 @@ constexpr int SimpleSum(const int num1, const int num2)
 // cached
 constexpr double Average(const double num1, const double num2, const double num3, const double num4,
     const double num5, const double num6, const double num7, const double num8, const double num9,
-    const double num10)
+    const double num10) noexcept
 {
     return (num1 + num2 + num3 + num4 + num5 + num6 + num7 + num8 + num9 + num10) / 10.00;
 }
@@ -211,7 +211,7 @@ void RemoveFromList(
     std::forward_list<std::string>& list, const std::string& str, bool case_sensitive)
 {
     list.remove_if(
-        [case_sensitive, &str](const std::string& val) noexcept
+        [case_sensitive, &str](const std::string& val)
         {
             if (case_sensitive)
             {


### PR DESCRIPTION
Adds support for serializing `std::variant`. Addresses that portion of #84 .